### PR TITLE
fix baseURL

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,10 +4,10 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
-  basePath: "/" + process.env.PAGES_BASE_URL || "",
-  assetPrefix: process.env.PAGES_BASE_URL
-    ? `/${process.env.PAGES_BASE_URL}/`
-    : "/",
+  //   basePath: "/" + process.env.PAGES_BASE_URL || "",
+  //   assetPrefix: process.env.PAGES_BASE_URL
+  //     ? `/${process.env.PAGES_BASE_URL}/`
+  //     : "/",
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
- Change Next.js baseURL back to defaults. (that would probably break the `https://biohackcloud.github.io/landing-page/` site but might make it work with `https://biohack.cloud` )